### PR TITLE
Remove border on maximized windows in metacity

### DIFF
--- a/src/metacity-1/metacity-theme-3.xml
+++ b/src/metacity-1/metacity-theme-3.xml
@@ -59,8 +59,8 @@
 </frame_geometry>
 
 <frame_geometry name="max" title_scale="medium" parent="normal" rounded_top_left="false" rounded_top_right="false">
-	<distance name="left_width" value="2" />
-	<distance name="right_width" value="2" />
+	<distance name="left_width" value="0" />
+	<distance name="right_width" value="0" />
 	<distance name="left_titlebar_edge" value="0"/>
 	<distance name="right_titlebar_edge" value="0"/>
 	<distance name="title_vertical_pad" value="2"/> <!-- 

--- a/usr/share/themes/Mint-Y/metacity-1/metacity-theme-3.xml
+++ b/usr/share/themes/Mint-Y/metacity-1/metacity-theme-3.xml
@@ -59,8 +59,8 @@
 </frame_geometry>
 
 <frame_geometry name="max" title_scale="medium" parent="normal" rounded_top_left="false" rounded_top_right="false">
-	<distance name="left_width" value="2" />
-	<distance name="right_width" value="2" />
+	<distance name="left_width" value="0" />
+	<distance name="right_width" value="0" />
 	<distance name="left_titlebar_edge" value="0"/>
 	<distance name="right_titlebar_edge" value="0"/>
 	<distance name="title_vertical_pad" value="2"/> <!-- 


### PR DESCRIPTION
The two commits present in this pull request removes the left, right and bottom borders on maximized windows in both of the metacity themes.

They don't look nice, and may introduce UX issues. One example of this is that the user can't merely place the cursor on the left edge of the screen and then initiate a scrolling action. In order to scroll, the user has to move the cursor a few pixel to the right.