### PR TITLE
Cinnamon menu text scrambled

### DIFF
--- a/usr/share/themes/Mint-Y/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-Y/cinnamon/cinnamon.css
@@ -24,7 +24,7 @@ stage {
     border: 1px solid #9ab87c;
     box-shadow: inset 0 2px 4px rgba(245, 245, 245, 0.05); }
   .popup-menu #notification .notification-button:hover, .popup-menu #notification .notification-icon-button:hover, .notification-button:hover, .notification-icon-button:hover, .modal-dialog-button-box .modal-dialog-button:hover, .menu-application-button-selected, .menu-category-button-selected, .sound-button:hover {
-    text-shadow: 0 1px rgba(255, 255, 255, 0);
+    /*text-shadow: 0 1px rgba(255, 255, 255, 0);*/
     color: #4a4a4a;
     background-color: white;
     border: 1px solid #d9d9d9;


### PR DESCRIPTION
Cinnamon menu's program text cannot render correctly, don't know what internal problem is there. But I solved this problem. I found this problem occurring while hover over categories because Cinnamon cannot render 'text-shadow' properly. If internal problem can be solved in upcoming 18.3 release then close this PR. Otherwise merge it please thus annoying problem keeps hidden till the real problem or bug detection.